### PR TITLE
Tag-driven PyPI release workflow (OIDC, no tokens)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,95 @@
+name: Release
+
+# Triggered by pushing a tag like `v3.4.1`. See "Releasing" in README for the
+# end-to-end flow and the one-time PyPI / GitHub setup this workflow expects.
+on:
+  push:
+    tags: ["v*"]
+
+# Don't cancel an in-flight publish — that could leave PyPI in a half-uploaded
+# state. We only need to prevent two concurrent attempts for the same tag.
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  test:
+    name: Offline tests (gate)
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+      - run: make install
+      - run: make ci
+
+  build:
+    name: Build sdist + wheel
+    needs: test
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Verify tag matches pyproject.toml version
+        run: |
+          tag="${GITHUB_REF#refs/tags/v}"
+          pkg=$(python -c "import tomllib; print(tomllib.load(open('pyproject.toml','rb'))['project']['version'])")
+          if [ "$tag" != "$pkg" ]; then
+            echo "::error::Tag v$tag does not match pyproject.toml version $pkg"
+            exit 1
+          fi
+          echo "Tag and pyproject version match: $tag"
+
+      - run: python -m pip install --upgrade build
+      - run: python -m build
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/
+          if-no-files-found: error
+
+  publish-pypi:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    # The `pypi` environment is what PyPI's Trusted Publisher config is bound
+    # to. Add Required reviewers to this environment in repo Settings to gate
+    # each release on a human approval.
+    environment:
+      name: pypi
+      url: https://pypi.org/project/apexomni/
+    permissions:
+      id-token: write   # mandatory for OIDC trusted publishing — no token needed
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: pypa/gh-action-pypi-publish@release/v1
+
+  github-release:
+    name: Create GitHub Release
+    needs: publish-pypi
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write    # to create the GitHub Release
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+      - uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          fail_on_unmatched_files: true

--- a/README.md
+++ b/README.md
@@ -22,6 +22,42 @@ machine will automatically run `make test` first and refuse to push if
 anything fails. CI runs the exact same `make test` target on every PR —
 keeping the local and remote gates identical.
 
+### Releasing
+
+Releases publish to PyPI automatically when a `v*` tag is pushed. The
+release workflow (`.github/workflows/release.yml`) reruns the test gate,
+builds the wheel + sdist, publishes to PyPI via OIDC trusted publishing
+(no long-lived token), and creates a GitHub Release with the artifacts.
+
+To cut a release from `main`:
+
+```bash
+# 1. Bump version in pyproject.toml, open + merge a PR.
+# 2. From the merged main commit:
+git checkout main && git pull
+git tag v3.4.1
+git push origin v3.4.1
+```
+
+The workflow refuses to publish if the tag does not match
+`pyproject.toml`'s `version`, and (if configured) waits on a Required
+reviewer for the `pypi` GitHub Environment before uploading.
+
+#### One-time setup (per project, per release target)
+
+1. **PyPI** — go to https://pypi.org/manage/project/apexomni/settings/publishing/
+   and add a Trusted Publisher with:
+   - Owner: `ApeX-Protocol`
+   - Repository: `apexpro-openapi`
+   - Workflow filename: `release.yml`
+   - Environment name: `pypi`
+
+2. **GitHub** — Settings → Environments → New environment named `pypi`:
+   - (Recommended) Add Required reviewers — every release waits for an
+     approval click before the PyPI upload step runs.
+   - (Recommended) Restrict deployment branches to `main` so a tag from
+     elsewhere can't trigger a release.
+
 ## Installation
 `apex omni` supports Python 3.9 through 3.12. The module can be installed manually or via [apexomni](https://pypi.org/project/apexomni/)  with `pip`:
 ```


### PR DESCRIPTION
## Summary

Adds `.github/workflows/release.yml` — a 4-job pipeline triggered by `v*` tag pushes:

1. **Offline tests (gate)** — reruns `make test` on the tagged commit so a stale or off-`main` tag can't ship a broken release.
2. **Build sdist + wheel** — fails fast if the tag name doesn't match `pyproject.toml`'s `version` (catches "tagged `v3.4.1` but forgot to bump").
3. **Publish to PyPI** — uses `pypa/gh-action-pypi-publish` with OIDC trusted publishing. **No long-lived PyPI token in repo secrets.** Bound to a `pypi` GitHub Environment so a Required reviewer can gate every release.
4. **Create GitHub Release** — attaches the built sdist + wheel and auto-generates release notes from the commits since the previous tag.

## One-time setup required before the first release tag works

This PR is safe to merge as-is — the workflow does nothing until a `v*` tag is pushed. But the **first tag will fail** unless these are configured:

### On PyPI
Go to https://pypi.org/manage/project/apexomni/settings/publishing/ → **Add a new trusted publisher**:

| Field | Value |
|-------|-------|
| Owner | `ApeX-Protocol` |
| Repository name | `apexpro-openapi` |
| Workflow filename | `release.yml` |
| Environment name | `pypi` |

(If the PyPI project page isn't accessible because no maintainer here owns it on PyPI, that's a blocker — sort the ownership first.)

### On GitHub
**Settings → Environments → New environment** named exactly `pypi`:

- **(Recommended) Required reviewers** — add one or two people who must approve each release before the PyPI upload step proceeds.
- **(Recommended) Deployment branches and tags** — restrict to `main` so a tag pushed from a feature branch can't trigger a release.

## How to cut a release after setup is done

```bash
# 1. Bump version in pyproject.toml on a PR, merge to main.
# 2. From the merged main commit:
git checkout main && git pull
git tag v3.4.1
git push origin v3.4.1
```

The PyPI URL, the GitHub Release page, and a cached wheel artifact all appear within ~5 minutes.

## Test plan

- [x] Tag/version match check verified locally with both passing (`v3.4.0` vs `version = \"3.4.0\"`) and failing (`v9.9.9`) cases.
- [x] `make test` green via pre-push hook.
- [ ] CI pass on this PR (workflow only parses on PRs — actual end-to-end will be verified by the first real tag push after PyPI + Environment are configured).